### PR TITLE
TICKET-013: Dockerfile and docker-compose for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+.git
+.env
+.env*.local
+*.test.ts
+*.test.tsx
+__tests__
+.github
+.eslintrc*
+coverage
+.DS_Store
+npm-debug.log*
+.vercel
+*.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Stage 2: Build the application
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Stage 3: Production runner
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy build output and production dependencies
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ npm run build
 npm start
 ```
 
+## Docker
+
+Build and run with Docker Compose:
+
+```bash
+cp .env.example .env
+# Edit .env with your values
+docker compose build
+docker compose up
+```
+
+The app will be available at [http://localhost:3000](http://localhost:3000).
+
+To run in detached mode:
+
+```bash
+docker compose up -d
+```
+
 ## API
 
 | Endpoint | Method | Response |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    build: .
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    env_file:
+      - .env
+    environment:
+      - PORT=${PORT:-3000}
+    restart: unless-stopped


### PR DESCRIPTION
## TICKET-13: Dockerfile and docker-compose for deployment

**Type:** infra | **Priority:** medium

### Description
Create multi-stage Dockerfile:
- Stage 1 (deps): FROM node:20-alpine AS deps, WORKDIR /app, COPY package.json package-lock.json ./, RUN npm ci
- Stage 2 (build): FROM node:20-alpine AS build, WORKDIR /app, COPY --from=deps /app/node_modules ./node_modules, COPY . ., RUN npm run build
- Stage 3 (production): FROM node:20-alpine AS runner, WORKDIR /app, ENV NODE_ENV=production, COPY --from=build /app/.next ./.next, COPY --from=build /app/node_modules ./node_modules, COPY --from=build /app/package.json ./package.json, COPY --from=build /app/public ./public (if exists), EXPOSE 3000, CMD ["npm", "start"]

Create docker-compose.yml:
- Service 'app': build: ., ports: ['3000:3000'], env_file: .env, restart: unless-stopped
- No database or redis (spec says no database)

Create .dockerignore:
node_modules, .next, .git, .env, *.test.ts, *.test.tsx, __tests__, .github, README.md, .eslintrc*

### Acceptance Criteria
docker compose build succeeds without errors. docker compose up starts the Next.js app on port 3000. GET http://localhost:3000/api/health returns 200. .dockerignore excludes node_modules, .git, tests, and .env. Multi-stage Dockerfile produces slim production image. No database services in docker-compose (spec requires none).

### Quality Gate Results
```
[{"name":"lint","passed":true},{"name":"typecheck","passed":true},{"name":"test","passed":true}]
```

---
*Generated by SwarmBoard Platform*