### PR TITLE
TICKET-045: Show coaching prompts only after their matching transcript line appears

### DIFF
--- a/src/__tests__/ticket-012-edge-cases.test.tsx
+++ b/src/__tests__/ticket-012-edge-cases.test.tsx
@@ -146,10 +146,15 @@ describe('TICKET-012 edge cases', () => {
   it('accumulates multiple coaching prompts', () => {
     mockUseSSE.mockReturnValue({
       ...defaultSSE(),
+      lines: [
+        { speaker: 'rep', text: 'Line 1', timestamp: 1 },
+        { speaker: 'prospect', text: 'Line 2', timestamp: 2 },
+        { speaker: 'rep', text: 'Line 3', timestamp: 3 },
+      ],
       prompts: [
-        { ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1 },
-        { ruleId: 'r2', ruleName: 'Open Questions', message: 'Ask open questions', timestamp: 2 },
-        { ruleId: 'r3', ruleName: 'Discovery', message: 'Dig deeper', timestamp: 3 },
+        { ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1, triggerLineIndex: 1 },
+        { ruleId: 'r2', ruleName: 'Open Questions', message: 'Ask open questions', timestamp: 2, triggerLineIndex: 2 },
+        { ruleId: 'r3', ruleName: 'Discovery', message: 'Dig deeper', timestamp: 3, triggerLineIndex: 3 },
       ],
     });
     render(<Home />);

--- a/src/__tests__/ticket-012-page.test.tsx
+++ b/src/__tests__/ticket-012-page.test.tsx
@@ -102,7 +102,8 @@ describe('Main page — acceptance criteria', () => {
   it('passes useSSE prompts to CoachingPanel', () => {
     mockUseSSE.mockReturnValue({
       ...defaultSSE(),
-      prompts: [{ ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1 }],
+      prompts: [{ ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1, triggerLineIndex: 1 }],
+      lines: [{ speaker: 'rep' as const, text: 'Hello', timestamp: 1 }],
     });
     render(<Home />);
     expect(screen.getByText('Active Listening')).toBeInTheDocument();

--- a/src/__tests__/ticket-012-qa-validation.test.tsx
+++ b/src/__tests__/ticket-012-qa-validation.test.tsx
@@ -295,8 +295,11 @@ describe('Main page — QA validation', () => {
   it('AC5: coaching prompts from useSSE render in CoachingPanel', () => {
     mockUseSSE.mockReturnValue({
       ...defaultSSE(),
+      lines: [
+        { speaker: 'rep', text: 'Line 1', timestamp: 1 },
+      ],
       prompts: [
-        { ruleId: 'r1', ruleName: 'Active Listening', message: 'Try reflecting back', timestamp: 1 },
+        { ruleId: 'r1', ruleName: 'Active Listening', message: 'Try reflecting back', timestamp: 1, triggerLineIndex: 1 },
       ],
     });
     render(<Home />);

--- a/src/__tests__/ticket-012-test-agent-qa.test.tsx
+++ b/src/__tests__/ticket-012-test-agent-qa.test.tsx
@@ -254,8 +254,11 @@ describe('Main page — test-agent acceptance', () => {
   it('AC5: coaching prompts render with rule name and message', () => {
     mockUseSSE.mockReturnValue({
       ...defaultSSE(),
+      lines: [
+        { speaker: 'rep', text: 'Line 1', timestamp: 1 },
+      ],
       prompts: [
-        { ruleId: 'r1', ruleName: 'Empathy Check', message: 'Acknowledge their concern', timestamp: 1 },
+        { ruleId: 'r1', ruleName: 'Empathy Check', message: 'Acknowledge their concern', timestamp: 1, triggerLineIndex: 1 },
       ],
     });
     render(<Home />);

--- a/src/__tests__/ticket-031-scorecard-inline.test.tsx
+++ b/src/__tests__/ticket-031-scorecard-inline.test.tsx
@@ -82,7 +82,7 @@ describe('TICKET-031: Scorecard renders inline not as modal overlay (updated for
       scorecard: mockScorecard,
       sessionComplete: true,
       lines: [{ speaker: 'rep', text: 'Hello prospect' }],
-      prompts: [{ ruleId: 'r1', ruleName: 'Test Rule', message: 'Test msg', timestamp: 1 }],
+      prompts: [{ ruleId: 'r1', ruleName: 'Test Rule', message: 'Test msg', timestamp: 1, triggerLineIndex: 1 }],
     });
     render(<Home />);
 

--- a/src/__tests__/ticket-033-sse-data-shape.test.tsx
+++ b/src/__tests__/ticket-033-sse-data-shape.test.tsx
@@ -163,7 +163,7 @@ describe('TICKET-033: SSE data shape destructuring', () => {
       });
       const prompts = JSON.parse(screen.getByTestId('prompts').textContent!);
       expect(prompts).toHaveLength(1);
-      expect(prompts[0]).toEqual({
+      expect(prompts[0]).toMatchObject({
         ruleId: 'no-questions',
         ruleName: 'No Discovery Questions',
         message: 'Try asking an open-ended question.',

--- a/src/__tests__/ticket-045-coaching-prompt-timing.test.tsx
+++ b/src/__tests__/ticket-045-coaching-prompt-timing.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useSSE } from '@/hooks/useSSE';
+
+// Mock EventSource
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  listeners: Record<string, ((event: { data: string }) => void)[]> = {};
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: { data: string }) => void) {
+    if (!this.listeners[type]) this.listeners[type] = [];
+    this.listeners[type].push(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  simulateOpen() {
+    if (this.onopen) this.onopen();
+  }
+
+  simulateEvent(type: string, data: unknown) {
+    const handlers = this.listeners[type] || [];
+    handlers.forEach((h) => h({ data: JSON.stringify(data) }));
+  }
+
+  static reset() {
+    MockEventSource.instances = [];
+  }
+
+  static latest(): MockEventSource {
+    return MockEventSource.instances[MockEventSource.instances.length - 1];
+  }
+}
+
+beforeAll(() => {
+  (global as Record<string, unknown>).EventSource = MockEventSource;
+});
+
+beforeEach(() => {
+  MockEventSource.reset();
+});
+
+// Test component that exposes useSSE values and applies the same filtering as session/page.tsx
+function TestComponent({ sessionId }: { sessionId: string | null }) {
+  const { lines, prompts } = useSSE(sessionId);
+
+  // Same filtering logic as session/page.tsx
+  const visiblePrompts = prompts.filter((p) => p.triggerLineIndex > 0 && p.triggerLineIndex <= lines.length);
+
+  return (
+    <div>
+      <span data-testid="lines-count">{lines.length}</span>
+      <span data-testid="all-prompts">{JSON.stringify(prompts)}</span>
+      <span data-testid="visible-prompts">{JSON.stringify(visiblePrompts)}</span>
+      <span data-testid="visible-count">{visiblePrompts.length}</span>
+    </div>
+  );
+}
+
+describe('TICKET-045: Coaching prompts appear only after triggering transcript line', () => {
+  it('shows no coaching prompts before any transcript lines arrive', () => {
+    render(<TestComponent sessionId="sess-1" />);
+
+    // Send a coaching prompt with no transcript lines
+    act(() => {
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'Filler Words',
+          message: 'Avoid filler words',
+          timestamp: 1000,
+        },
+      });
+    });
+
+    // Prompt is stored but not visible (triggerLineIndex = 0, lines.length = 0)
+    expect(screen.getByTestId('lines-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('visible-count')).toHaveTextContent('0');
+    const allPrompts = JSON.parse(screen.getByTestId('all-prompts').textContent!);
+    expect(allPrompts).toHaveLength(1);
+    expect(allPrompts[0].triggerLineIndex).toBe(0);
+  });
+
+  it('shows coaching prompt only after its triggering transcript line is visible', () => {
+    render(<TestComponent sessionId="sess-1" />);
+
+    // Send transcript line 1, then coaching prompt triggered by line 1
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Hello there', timestamp: 1000 },
+      });
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'Active Listening',
+          message: 'Try reflecting back',
+          timestamp: 1100,
+        },
+      });
+    });
+
+    // Line 1 is visible, prompt triggered at line 1 should be visible
+    expect(screen.getByTestId('lines-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('visible-count')).toHaveTextContent('1');
+    const visible = JSON.parse(screen.getByTestId('visible-prompts').textContent!);
+    expect(visible[0].ruleName).toBe('Active Listening');
+    expect(visible[0].triggerLineIndex).toBe(1);
+  });
+
+  it('delays coaching prompt visibility until triggering line is displayed', () => {
+    render(<TestComponent sessionId="sess-1" />);
+
+    // Simulate: transcript line 1 arrives, triggers a rule, but Claude responds
+    // after line 2 arrives, so coaching prompt has triggerLineIndex=2
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 1', timestamp: 1000 },
+      });
+    });
+
+    // After line 1: no prompts yet
+    expect(screen.getByTestId('visible-count')).toHaveTextContent('0');
+
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'prospect', text: 'Line 2', timestamp: 2000 },
+      });
+      // Coaching prompt arrives after line 2
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'No Questions',
+          message: 'Ask more questions',
+          timestamp: 2100,
+        },
+      });
+    });
+
+    // Prompt triggered at line 2, 2 lines visible — should show
+    expect(screen.getByTestId('lines-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('visible-count')).toHaveTextContent('1');
+  });
+
+  it('shows all prompts once transcript is complete', () => {
+    render(<TestComponent sessionId="sess-1" />);
+
+    // Send 3 lines with 2 prompts triggered at different points
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 1', timestamp: 1000 },
+      });
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'Filler Words',
+          message: 'Avoid filler',
+          timestamp: 1100,
+        },
+      });
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'prospect', text: 'Line 2', timestamp: 2000 },
+      });
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 3', timestamp: 3000 },
+      });
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r2',
+          ruleName: 'No Next Steps',
+          message: 'Propose next steps',
+          timestamp: 3100,
+        },
+      });
+    });
+
+    // All 3 lines visible, both prompts should show
+    expect(screen.getByTestId('lines-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('visible-count')).toHaveTextContent('2');
+  });
+
+  it('tags each coaching prompt with the correct triggerLineIndex', () => {
+    render(<TestComponent sessionId="sess-1" />);
+
+    act(() => {
+      // Line 1
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 1', timestamp: 1000 },
+      });
+      // Prompt triggered after line 1
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'Rule A',
+          message: 'Message A',
+          timestamp: 1100,
+        },
+      });
+      // Lines 2 and 3
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'prospect', text: 'Line 2', timestamp: 2000 },
+      });
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 3', timestamp: 3000 },
+      });
+      // Prompt triggered after line 3
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r2',
+          ruleName: 'Rule B',
+          message: 'Message B',
+          timestamp: 3100,
+        },
+      });
+    });
+
+    const allPrompts = JSON.parse(screen.getByTestId('all-prompts').textContent!);
+    expect(allPrompts[0].triggerLineIndex).toBe(1);
+    expect(allPrompts[1].triggerLineIndex).toBe(3);
+  });
+
+  it('resets triggerLineIndex tracking when session changes', () => {
+    const { rerender } = render(<TestComponent sessionId="sess-1" />);
+
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'Line 1', timestamp: 1000 },
+      });
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'prospect', text: 'Line 2', timestamp: 2000 },
+      });
+    });
+
+    // Reset session
+    rerender(<TestComponent sessionId={null} />);
+    rerender(<TestComponent sessionId="sess-2" />);
+
+    // First prompt in new session should have triggerLineIndex based on new line count
+    act(() => {
+      MockEventSource.latest().simulateEvent('transcript', {
+        line: { speaker: 'rep', text: 'New line 1', timestamp: 5000 },
+      });
+      MockEventSource.latest().simulateEvent('coaching_prompt', {
+        prompt: {
+          ruleId: 'r1',
+          ruleName: 'Rule A',
+          message: 'Message A',
+          timestamp: 5100,
+        },
+      });
+    });
+
+    const allPrompts = JSON.parse(screen.getByTestId('all-prompts').textContent!);
+    expect(allPrompts).toHaveLength(1);
+    // Should be 1 (first line of new session), not 3 (carried over)
+    expect(allPrompts[0].triggerLineIndex).toBe(1);
+  });
+});

--- a/src/__tests__/ticket-051-scorecard-ux.test.tsx
+++ b/src/__tests__/ticket-051-scorecard-ux.test.tsx
@@ -54,7 +54,7 @@ describe('TICKET-051: Scorecard UX — keep transcript+coaching visible, scoreca
       sessionComplete: true,
       scorecard: mockScorecard,
       lines: [{ speaker: 'rep', text: 'Hi there' }],
-      prompts: [{ ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1 }],
+      prompts: [{ ruleId: 'r1', ruleName: 'Active Listening', message: 'Reflect back', timestamp: 1, triggerLineIndex: 1 }],
     });
     render(<Home />);
 
@@ -119,7 +119,7 @@ describe('TICKET-051: Scorecard UX — keep transcript+coaching visible, scoreca
       sessionComplete: true,
       scorecard: mockScorecard,
       lines: [{ speaker: 'rep', text: 'Test transcript line' }],
-      prompts: [{ ruleId: 'r1', ruleName: 'Test Rule', message: 'Test coaching', timestamp: 1 }],
+      prompts: [{ ruleId: 'r1', ruleName: 'Test Rule', message: 'Test coaching', timestamp: 1, triggerLineIndex: 1 }],
     });
     render(<Home />);
 

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSSE } from '@/hooks/useSSE';
 import TranscriptPanel from '@/components/TranscriptPanel';
 import CoachingPanel from '@/components/CoachingPanel';
@@ -23,6 +23,12 @@ export default function Home() {
   const [scorecardLoading, setScorecardLoading] = useState(false);
 
   const { lines, prompts, scorecard, sessionComplete, isConnected } = useSSE(sessionId);
+
+  // Only show coaching prompts whose triggering transcript line is already visible
+  const visiblePrompts = useMemo(
+    () => prompts.filter((p) => p.triggerLineIndex > 0 && p.triggerLineIndex <= lines.length),
+    [prompts, lines.length]
+  );
 
   // Fetch call types on mount
   useEffect(() => {
@@ -189,7 +195,7 @@ export default function Home() {
           <div className="grid h-full grid-cols-1 gap-6 md:grid-cols-2">
             <TranscriptPanel lines={lines} />
             <CoachingPanel
-              prompts={prompts}
+              prompts={visiblePrompts}
               sessionCompleted={sessionStatus === 'completed'}
               scorecardLoading={scorecardLoading}
               onGenerateScorecard={handleGenerateScorecard}

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -3,9 +3,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { TranscriptLine, CoachingPrompt, Scorecard } from '@/types';
 
+export interface CoachingPromptWithTrigger extends CoachingPrompt {
+  triggerLineIndex: number;
+}
+
 interface UseSSEReturn {
   lines: TranscriptLine[];
-  prompts: CoachingPrompt[];
+  prompts: CoachingPromptWithTrigger[];
   scorecard: Scorecard | null;
   sessionComplete: boolean;
   isConnected: boolean;
@@ -13,11 +17,12 @@ interface UseSSEReturn {
 
 export function useSSE(sessionId: string | null): UseSSEReturn {
   const [lines, setLines] = useState<TranscriptLine[]>([]);
-  const [prompts, setPrompts] = useState<CoachingPrompt[]>([]);
+  const [prompts, setPrompts] = useState<CoachingPromptWithTrigger[]>([]);
   const [scorecard, setScorecard] = useState<Scorecard | null>(null);
   const [sessionComplete, setSessionComplete] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const lineCountRef = useRef(0);
 
   const cleanup = useCallback(() => {
     if (eventSourceRef.current) {
@@ -34,6 +39,7 @@ export function useSSE(sessionId: string | null): UseSSEReturn {
       setPrompts([]);
       setScorecard(null);
       setSessionComplete(false);
+      lineCountRef.current = 0;
       return;
     }
 
@@ -49,20 +55,24 @@ export function useSSE(sessionId: string | null): UseSSEReturn {
 
     es.addEventListener('transcript', (event: MessageEvent) => {
       const { line } = JSON.parse(event.data) as { line: TranscriptLine };
+      lineCountRef.current += 1;
       setLines((prev) => [...prev, line]);
     });
 
     es.addEventListener('coaching_prompt', (event: MessageEvent) => {
       const { prompt } = JSON.parse(event.data) as { prompt: CoachingPrompt };
+      const promptWithTrigger: CoachingPromptWithTrigger = {
+        ...prompt,
+        triggerLineIndex: lineCountRef.current,
+      };
       setPrompts((prev) => {
         const existingIdx = prev.findIndex((p) => p.ruleId === prompt.ruleId);
         if (existingIdx >= 0) {
-          // Replace existing prompt for this rule with the latest one
           const updated = [...prev];
-          updated[existingIdx] = prompt;
+          updated[existingIdx] = promptWithTrigger;
           return updated;
         }
-        return [...prev, prompt];
+        return [...prev, promptWithTrigger];
       });
     });
 


### PR DESCRIPTION
## TICKET-45: Show coaching prompts only after their matching transcript line appears

**Type:** bug | **Priority:** high

### Description
Coaching prompts appear before the transcript streams. Fix: in session/page.tsx, hide coaching prompts until the transcript line that triggered them is visible. Simple approach — track the count of streamed lines, only show coaching prompts triggered by lines already displayed. The coaching prompt has a timestamp that corresponds to when in the transcript it was triggered.

### Acceptance Criteria
- [ ] No coaching prompts visible before transcript starts
- [ ] Each coaching prompt appears only after its triggering transcript line is visible
- [ ] All prompts eventually show as transcript completes

### Quality Gate Results
```
[{"name":"lint","passed":true,"warnings":"1 warning(s) in changed files (non-blocking)"},{"name":"typecheck","passed":true},{"name":"test","passed":true,"output":"All test failures are pre-existing and unrelated to this PR","warnings":"7 pre-existing test failure(s) (non-blocking): src/__tests__/ticket-047-scorecard-inline.test.tsx, src/__tests__/ticket-021-integration.test.ts, src/__tests__/ticket-021-qa-validation.test.ts, /tmp/swarmboard-agent-cmmsnsjxp00mxsd1ccsdl94ev/src/__tests__/ticket-021-qa-validation.test.ts, /tmp/swarmboard-agent-cmmsnsjxp00mxsd1ccsdl94ev/src/__tests__/ticket-027-test-agent-qa.test.ts, src/__tests__/ticket-027-test-agent-qa.test.ts, /tmp/swarmboard-agent-cmmsnsjxp00mxsd1ccsdl94ev/src/__tests__/ticket-021-integration.test.ts"},{"name":"build","passed":true}]
```

---
*Generated by SwarmBoard Platform*