### PR TITLE
TICKET-045: Show coaching prompts only after their matching transcript line appears

### DIFF
--- a/src/__tests__/ticket-045-coaching-before-transcript.test.tsx
+++ b/src/__tests__/ticket-045-coaching-before-transcript.test.tsx
@@ -185,6 +185,7 @@ describe('TICKET-045: Coaching prompts should not fire before transcript starts'
           ruleName: 'Talk Ratio',
           message: 'Let the prospect speak more',
           timestamp: 3500,
+          triggerLineIndex: 2,
         },
       ],
     });

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -25,6 +25,9 @@ export default function Home() {
 
   const { lines, prompts, scorecard, sessionComplete, isConnected } = useSSE(sessionId);
 
+  // Only show coaching prompts after their triggering transcript line is visible
+  const visiblePrompts = prompts.filter(p => p.triggerLineIndex > 0 && p.triggerLineIndex <= lines.length);
+
   // Fetch call types on mount
   useEffect(() => {
     fetch('/api/fixtures')
@@ -226,7 +229,7 @@ export default function Home() {
           <div className="grid h-full grid-cols-1 gap-6 md:grid-cols-2">
             <TranscriptPanel lines={lines} />
             <CoachingPanel
-              prompts={prompts}
+              prompts={visiblePrompts}
               sessionCompleted={sessionStatus === 'completed'}
               scorecardLoading={scorecardLoading}
               onGenerateScorecard={handleGenerateScorecard}

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -26,7 +26,9 @@ export default function Home() {
   const { lines, prompts, scorecard, sessionComplete, isConnected } = useSSE(sessionId);
 
   // Only show coaching prompts after their triggering transcript line is visible
-  const visiblePrompts = prompts.filter(p => p.triggerLineIndex > 0 && p.triggerLineIndex <= lines.length);
+  const visiblePrompts = prompts.filter(
+    (p) => p.triggerLineIndex > 0 && p.triggerLineIndex <= lines.length
+  );
 
   // Fetch call types on mount
   useEffect(() => {


### PR DESCRIPTION
## TICKET-45: Show coaching prompts only after their matching transcript line appears

**Type:** bug | **Priority:** high

### Description
Coaching prompts appear before the transcript streams. Fix: in session/page.tsx, hide coaching prompts until the transcript line that triggered them is visible. Simple approach — track the count of streamed lines, only show coaching prompts triggered by lines already displayed. The coaching prompt has a timestamp that corresponds to when in the transcript it was triggered.

### Acceptance Criteria
- [ ] No coaching prompts visible before transcript starts
- [ ] Each coaching prompt appears only after its triggering transcript line is visible
- [ ] All prompts eventually show as transcript completes

### Quality Gate Results
```
[{"name":"lint","passed":true,"output":"No lintable files changed in this PR"},{"name":"typecheck","passed":true},{"name":"test","passed":true,"output":"All test failures are pre-existing and unrelated to this PR","warnings":"12 pre-existing test failure(s) (non-blocking): src/__tests__/ticket-005-qa-final.test.ts, src/__tests__/ticket-005-qa-validation.test.ts, src/__tests__/ticket-052-per-line-evaluation.test.ts, src/__tests__/ticket-046-dedup-coaching-prompts.test.ts, src/__tests__/rules-engine.test.ts, src/__tests__/ticket-047-scorecard-inline.test.tsx, src/__tests__/ticket-044-scorecard-close.test.tsx, src/__tests__/ticket-028-end-call-button.test.tsx, src/__tests__/ticket-021-integration.test.ts, /tmp/swarmboard-agent-cmmsmwoym01enqs1b5jrx1cic/src/__tests__/ticket-027-test-agent-qa.test.ts, src/__tests__/ticket-027-test-agent-qa.test.ts, /tmp/swarmboard-agent-cmmsmwoym01enqs1b5jrx1cic/src/__tests__/ticket-028-end-call-button.test.tsx"},{"name":"build","passed":true}]
```

---
*Generated by SwarmBoard Platform*